### PR TITLE
feat: resize small wallpapers to 4000px wide using ImageMagick

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,13 +11,14 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    container: golang:1.25-alpine
     permissions:
       contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libmagickwand-dev
+        run: apk add --no-cache imagemagick-dev pkgconf gcc musl-dev
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,6 +16,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libmagickwand-dev
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: golang:1.25-alpine
     steps:
       - uses: actions/checkout@v6
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 1.25.x
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libmagickwand-dev
+        run: apk add --no-cache imagemagick-dev pkgconf gcc musl-dev
       - name: Install dependencies
         run: go get .
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libmagickwand-dev
       - name: Install dependencies
         run: go get .
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,30 @@ on:
   - push
 jobs:
   build:
-    runs-on: ubuntu-latest
-    container: golang:1.25-alpine
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            container: golang:1.25-alpine
+          - os: macos-latest
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v6
-      - name: Install system dependencies
+      - name: Setup Go
+        if: runner.os == 'macOS'
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.25.x
+      - name: Install deps (Linux)
+        if: runner.os == 'Linux'
         run: apk add --no-cache imagemagick-dev pkgconf gcc musl-dev
+      - name: Install deps (macOS)
+        if: runner.os == 'macOS'
+        run: brew install imagemagick
       - name: Install dependencies
         run: go get .
       - name: Build
         run: go build -v ./...
-      - name: Test with the Go CLI
+      - name: Test
         run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ doc/
 
 .DS_Store
 /server
+/uploader

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.26 AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libc6-dev \
+    libmagickwand-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
@@ -21,6 +22,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    libmagickwand-6.q16-6 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /server /usr/local/bin/server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.26 AS builder
+FROM golang:1.26-alpine AS builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apk add --no-cache \
     gcc \
-    libc6-dev \
-    libmagickwand-dev \
-    && rm -rf /var/lib/apt/lists/*
+    musl-dev \
+    imagemagick-dev \
+    pkgconf
 
 WORKDIR /usr/src/app
 
@@ -18,12 +18,11 @@ ENV CGO_ENABLED=1
 RUN go build -ldflags="-s -w" -o /server ./cmd/server
 RUN go build -ldflags="-s -w" -o /uploader ./cmd/uploader
 
-FROM debian:bookworm-slim
+FROM alpine:latest
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apk add --no-cache \
     ca-certificates \
-    libmagickwand-6.q16-6 \
-    && rm -rf /var/lib/apt/lists/*
+    imagemagick-libs
 
 COPY --from=builder /server /usr/local/bin/server
 COPY --from=builder /uploader /usr/local/bin/uploader

--- a/cmd/uploader/main.go
+++ b/cmd/uploader/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/icco/wallpapers"
 	"github.com/icco/wallpapers/analysis"
 	"github.com/icco/wallpapers/db"
-	"gopkg.in/gographics/imagick.v2/imagick"
+	"gopkg.in/gographics/imagick.v3/imagick"
 )
 
 const DropboxPath = "/Photos/Wallpapers/DesktopWallpapers"
@@ -229,7 +229,7 @@ func resizeToMinWidth(path string, minWidth uint) (bool, error) {
 
 	h := mw.GetImageHeight()
 	newH := uint(float64(h) * float64(minWidth) / float64(w))
-	if err := mw.ResizeImage(minWidth, newH, imagick.FILTER_LANCZOS, 1.0); err != nil {
+	if err := mw.ResizeImage(minWidth, newH, imagick.FILTER_LANCZOS); err != nil {
 		return false, fmt.Errorf("imagick resize: %w", err)
 	}
 

--- a/cmd/uploader/main.go
+++ b/cmd/uploader/main.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"log"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strings"
@@ -114,6 +115,13 @@ func walkFn(path string, info fs.FileInfo, err error) error {
 	// log existence
 	knownLocalFiles[newName] = true
 
+	// Resize if smaller than 4000px wide
+	if resized, rerr := resizeToMinWidth(newPath, 4000); rerr != nil {
+		log.Printf("warning: could not resize %q: %v", newName, rerr)
+	} else if resized {
+		log.Printf("resized %q to 4000px width", newName)
+	}
+
 	// Upload
 	//gosec:disable G304 We are uploading a file, so we need to read it
 	dat, err := os.ReadFile(newPath)
@@ -200,6 +208,19 @@ func analyzeAndStore(ctx context.Context, filePath, filename string, data []byte
 	log.Printf("stored metadata for %q: %dx%d, %d colors, %d words",
 		filename, info.Width, info.Height, len(info.Colors), len(info.Words))
 	return nil
+}
+
+// resizeToMinWidth uses ImageMagick to enlarge the image at path to minWidth pixels wide
+// (maintaining aspect ratio) if its current width is less than minWidth.
+// Returns true if the image was resized.
+func resizeToMinWidth(path string, minWidth int) (bool, error) {
+	geometry := fmt.Sprintf("%dx<", minWidth)
+	//nolint:gosec // G204: path is derived from a trusted local directory walk
+	out, err := exec.Command("magick", path, "-resize", geometry, path).CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("magick: %w: %s", err, out)
+	}
+	return true, nil
 }
 
 // shouldRandomlyReanalyze returns true approximately 10% of the time using crypto/rand.

--- a/cmd/uploader/main.go
+++ b/cmd/uploader/main.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"log"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/icco/wallpapers"
 	"github.com/icco/wallpapers/analysis"
 	"github.com/icco/wallpapers/db"
+	"gopkg.in/gographics/imagick.v3/imagick"
 )
 
 const DropboxPath = "/Photos/Wallpapers/DesktopWallpapers"
@@ -26,6 +26,9 @@ var (
 )
 
 func main() {
+	imagick.Initialize()
+	defer imagick.Terminate()
+
 	ctx := context.Background()
 
 	// Open database
@@ -210,15 +213,30 @@ func analyzeAndStore(ctx context.Context, filePath, filename string, data []byte
 	return nil
 }
 
-// resizeToMinWidth uses ImageMagick to enlarge the image at path to minWidth pixels wide
-// (maintaining aspect ratio) if its current width is less than minWidth.
-// Returns true if the image was resized.
-func resizeToMinWidth(path string, minWidth int) (bool, error) {
-	geometry := fmt.Sprintf("%dx<", minWidth)
-	//nolint:gosec // G204: path is derived from a trusted local directory walk
-	out, err := exec.Command("magick", path, "-resize", geometry, path).CombinedOutput()
-	if err != nil {
-		return false, fmt.Errorf("magick: %w: %s", err, out)
+// resizeToMinWidth uses ImageMagick (via gopkg.in/gographics/imagick.v3) to enlarge the image
+// at path to minWidth pixels wide (maintaining aspect ratio) if its current width is less than
+// minWidth. Returns true if the image was resized and written back to disk.
+func resizeToMinWidth(path string, minWidth uint) (bool, error) {
+	mw := imagick.NewMagickWand()
+	defer mw.Destroy()
+
+	if err := mw.ReadImage(path); err != nil {
+		return false, fmt.Errorf("imagick read: %w", err)
+	}
+
+	w := mw.GetImageWidth()
+	if w >= minWidth {
+		return false, nil
+	}
+
+	h := mw.GetImageHeight()
+	newH := uint(float64(h) * float64(minWidth) / float64(w))
+	if err := mw.ResizeImage(minWidth, newH, imagick.FILTER_LANCZOS); err != nil {
+		return false, fmt.Errorf("imagick resize: %w", err)
+	}
+
+	if err := mw.WriteImage(path); err != nil {
+		return false, fmt.Errorf("imagick write: %w", err)
 	}
 	return true, nil
 }

--- a/cmd/uploader/main.go
+++ b/cmd/uploader/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/icco/wallpapers"
 	"github.com/icco/wallpapers/analysis"
 	"github.com/icco/wallpapers/db"
-	"github.com/gographics/imagick/imagick"
+	"gopkg.in/gographics/imagick.v2/imagick"
 )
 
 const DropboxPath = "/Photos/Wallpapers/DesktopWallpapers"
@@ -229,7 +229,7 @@ func resizeToMinWidth(path string, minWidth uint) (bool, error) {
 
 	h := mw.GetImageHeight()
 	newH := uint(float64(h) * float64(minWidth) / float64(w))
-	if err := mw.ResizeImage(minWidth, newH, imagick.FILTER_LANCZOS); err != nil {
+	if err := mw.ResizeImage(minWidth, newH, imagick.FILTER_LANCZOS, 1.0); err != nil {
 		return false, fmt.Errorf("imagick resize: %w", err)
 	}
 

--- a/cmd/uploader/main.go
+++ b/cmd/uploader/main.go
@@ -213,9 +213,7 @@ func analyzeAndStore(ctx context.Context, filePath, filename string, data []byte
 	return nil
 }
 
-// resizeToMinWidth uses ImageMagick (via gopkg.in/gographics/imagick.v3) to enlarge the image
-// at path to minWidth pixels wide (maintaining aspect ratio) if its current width is less than
-// minWidth. Returns true if the image was resized and written back to disk.
+// resizeToMinWidth upscales path to minWidth pixels wide if smaller, preserving aspect ratio.
 func resizeToMinWidth(path string, minWidth uint) (bool, error) {
 	mw := imagick.NewMagickWand()
 	defer mw.Destroy()

--- a/cmd/uploader/main.go
+++ b/cmd/uploader/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/icco/wallpapers"
 	"github.com/icco/wallpapers/analysis"
 	"github.com/icco/wallpapers/db"
-	"gopkg.in/gographics/imagick.v3/imagick"
+	"github.com/gographics/imagick/imagick"
 )
 
 const DropboxPath = "/Photos/Wallpapers/DesktopWallpapers"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/EdlinOrg/prominentcolor v1.0.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
-	github.com/gographics/imagick v3.2.0+incompatible
 	github.com/icco/gutil v0.0.0-20260209153821-fe9ae42fb376
 	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/tjarratt/babble v0.0.0-20210505082055-cbca2a4833c1
@@ -17,6 +16,7 @@ require (
 	golang.org/x/image v0.37.0
 	google.golang.org/api v0.272.0
 	google.golang.org/genai v1.51.0
+	gopkg.in/gographics/imagick.v2 v2.7.1
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
 )
@@ -81,5 +81,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/gographics/imagick.v3 v3.7.3 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	golang.org/x/image v0.37.0
 	google.golang.org/api v0.272.0
 	google.golang.org/genai v1.51.0
+	gopkg.in/gographics/imagick.v3 v3.7.3
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/EdlinOrg/prominentcolor v1.0.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
+	github.com/gographics/imagick v3.2.0+incompatible
 	github.com/icco/gutil v0.0.0-20260209153821-fe9ae42fb376
 	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/tjarratt/babble v0.0.0-20210505082055-cbca2a4833c1
@@ -16,7 +17,6 @@ require (
 	golang.org/x/image v0.37.0
 	google.golang.org/api v0.272.0
 	google.golang.org/genai v1.51.0
-	gopkg.in/gographics/imagick.v3 v3.7.3
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
 )
@@ -81,4 +81,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/gographics/imagick.v3 v3.7.3 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	golang.org/x/image v0.37.0
 	google.golang.org/api v0.272.0
 	google.golang.org/genai v1.51.0
-	gopkg.in/gographics/imagick.v2 v2.7.1
+	gopkg.in/gographics/imagick.v3 v3.7.3
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
 )

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ4
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/gographics/imagick v3.2.0+incompatible h1:KeoHcmV7bVRKnj6tXTIcEGnyDg8kO0vPNUTC/5HzwOI=
-github.com/gographics/imagick v3.2.0+incompatible/go.mod h1:gk55mrttmUSR+Vt6dxnxuD7EKU/3e5Ehe8HRGVCI8mw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -264,8 +262,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
-gopkg.in/gographics/imagick.v3 v3.7.3 h1:Hy2MbJKLJ/9T3ZuV1zwBOy09O9prf2MCCVpM7bcZdpY=
-gopkg.in/gographics/imagick.v3 v3.7.3/go.mod h1:7I4S9VWdwr88yzYi7g+ZL4H8oZuH9cmSQI7GsZCcYFM=
+gopkg.in/gographics/imagick.v2 v2.7.1 h1:7k8qhqYwF093KJ/vmWJHoOkI9zzLOhL/h2qt5LFc7iw=
+gopkg.in/gographics/imagick.v2 v2.7.1/go.mod h1:i87+p+KdGE2FerYMoj6JWEqsmpTWyYM8LQqMDtu5Hws=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
-gopkg.in/gographics/imagick.v2 v2.7.1 h1:7k8qhqYwF093KJ/vmWJHoOkI9zzLOhL/h2qt5LFc7iw=
-gopkg.in/gographics/imagick.v2 v2.7.1/go.mod h1:i87+p+KdGE2FerYMoj6JWEqsmpTWyYM8LQqMDtu5Hws=
+gopkg.in/gographics/imagick.v3 v3.7.3 h1:Hy2MbJKLJ/9T3ZuV1zwBOy09O9prf2MCCVpM7bcZdpY=
+gopkg.in/gographics/imagick.v3 v3.7.3/go.mod h1:7I4S9VWdwr88yzYi7g+ZL4H8oZuH9cmSQI7GsZCcYFM=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/gographics/imagick.v3 v3.7.3 h1:Hy2MbJKLJ/9T3ZuV1zwBOy09O9prf2MCCVpM7bcZdpY=
+gopkg.in/gographics/imagick.v3 v3.7.3/go.mod h1:7I4S9VWdwr88yzYi7g+ZL4H8oZuH9cmSQI7GsZCcYFM=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ4
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/gographics/imagick v3.2.0+incompatible h1:KeoHcmV7bVRKnj6tXTIcEGnyDg8kO0vPNUTC/5HzwOI=
+github.com/gographics/imagick v3.2.0+incompatible/go.mod h1:gk55mrttmUSR+Vt6dxnxuD7EKU/3e5Ehe8HRGVCI8mw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=


### PR DESCRIPTION
## Summary

- Upscale wallpapers narrower than 4000px to exactly 4000px wide (aspect ratio preserved) during the upload walk
- Uses `gopkg.in/gographics/imagick.v3` — Go bindings for ImageMagick's MagickWand C API — instead of shelling out to the `magick` binary

## Implementation

### Resize function

```go
func resizeToMinWidth(path string, minWidth uint) (bool, error) {
    mw := imagick.NewMagickWand()
    defer mw.Destroy()

    if err := mw.ReadImage(path); err != nil {
        return false, fmt.Errorf("imagick read: %w", err)
    }

    w := mw.GetImageWidth()
    if w >= minWidth {
        return false, nil // already large enough
    }

    h := mw.GetImageHeight()
    newH := uint(float64(h) * float64(minWidth) / float64(w))
    if err := mw.ResizeImage(minWidth, newH, imagick.FILTER_LANCZOS); err != nil {
        return false, fmt.Errorf("imagick resize: %w", err)
    }

    if err := mw.WriteImage(path); err != nil {
        return false, fmt.Errorf("imagick write: %w", err)
    }
    return true, nil
}
```

`imagick.Initialize()` / `imagick.Terminate()` are called once in `main()` as required by the library.

### Approach comparison

| | `nfnt/resize` | `exec magick` | `gographics/imagick` |
|---|---|---|---|
| Maintained | No (2018) | Yes | Yes |
| Format support | JPEG, PNG only | All ImageMagick formats | All ImageMagick formats |
| Dependency | Pure Go | `magick` binary in PATH | `libmagickwand-dev` C library |
| CGO | No | No | Yes |

### Uploader walk order

```
rename → resize if width < 4000 → read file → CRC check → upload → analyze
```

Resizing happens before the CRC comparison, so any resized image will be detected as changed and re-uploaded automatically.