### PR TITLE
Pin alpine:latest to alpine:3.21 in runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV CGO_ENABLED=1
 RUN go build -ldflags="-s -w" -o /server ./cmd/server
 RUN go build -ldflags="-s -w" -o /uploader ./cmd/uploader
 
-FROM alpine:latest
+FROM alpine:3.21
 
 RUN apk add --no-cache \
     ca-certificates \


### PR DESCRIPTION
## Problem

The `Dockerfile` final stage used an unpinned base image:

```dockerfile
FROM alpine:latest
```

Using `alpine:latest` is non-reproducible: two builds at different times pull different Alpine base images. This can silently introduce:
- Changed package versions with different (possibly vulnerable) transitive dependencies
- Package removals that break runtime behavior
- Inconsistent behaviour between environments

The builder stage is already well-structured (multi-stage, go mod download caching, `-ldflags="-s -w"`), but the runtime stage did not benefit from a pinned base.

## Fix

Pin `FROM alpine:latest` → `FROM alpine:3.21` so builds are deterministic and auditable.

## Testing

```bash
docker build -t wallpapers .
docker run --rm -e PORT=8080 -p 8080:8080 wallpapers
```

## Audit notes

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile final stage | `FROM alpine:latest` unpinned | **Fixed (this PR)** |
| Dockerfile final stage | No `USER` instruction (runs as root) | Skipped — interaction with `wallpapers.db` write permissions needs investigation before adding a non-root user; follow-up PR recommended |
| `go.mod` | Dependencies look current | No action needed |
