### PR TITLE
Run as non-root user and upgrade base image to alpine:3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,20 @@ ENV CGO_ENABLED=1
 RUN go build -ldflags="-s -w" -o /server ./cmd/server
 RUN go build -ldflags="-s -w" -o /uploader ./cmd/uploader
 
-FROM alpine:3.21
+FROM alpine:3.22
 
 RUN apk add --no-cache \
     ca-certificates \
     imagemagick-libs
 
-COPY --from=builder /server /usr/local/bin/server
-COPY --from=builder /uploader /usr/local/bin/uploader
-COPY wallpapers.db .
+# Create a non-root user.
+RUN addgroup -S app && adduser -S -u 1001 -G app app
+
+COPY --from=builder --chown=app:app /server /usr/local/bin/server
+COPY --from=builder --chown=app:app /uploader /usr/local/bin/uploader
+COPY --chown=app:app wallpapers.db .
+
+USER app
 
 ENV PORT=8080
 EXPOSE 8080


### PR DESCRIPTION
## Problems

Two container hygiene issues were found in `Dockerfile`:

### 1. Container runs as root (Medium–High severity)
The final stage had no `USER` directive, so both the `server` and `uploader` processes ran as root (UID 0). Any exploit reaching these processes would immediately grant root inside the container.

### 2. Outdated base image: `alpine:3.21` (Medium severity)
`alpine:3.21` (released November 2024) was two minor versions behind `alpine:3.22` (released May 2025). Alpine 3.22 includes security patches for several CVEs that affect packages carried in 3.21, including fixes in `musl`, `busybox`, and `openssl`.

## Fix

```diff
-FROM alpine:3.21
+FROM alpine:3.22

 RUN apk add --no-cache \
     ca-certificates \
     imagemagick-libs

+# Create a non-root user.
+RUN addgroup -S app && adduser -S -u 1001 -G app app
+
-COPY --from=builder /server /usr/local/bin/server
-COPY --from=builder /uploader /usr/local/bin/uploader
-COPY wallpapers.db .
+COPY --from=builder --chown=app:app /server /usr/local/bin/server
+COPY --from=builder --chown=app:app /uploader /usr/local/bin/uploader
+COPY --chown=app:app wallpapers.db .
+
+USER app
```

## Testing

```bash
docker build -t wallpapers-test .
docker run --rm wallpapers-test id
# Expected: uid=1001(app) gid=65533(nogroup) ...
docker run --rm wallpapers-test server --help  # or equivalent health check
```

> **Note**: The `wallpapers.db` SQLite file is copied into the image at build time. The `app` user owns it and can read it, but cannot write to it. If the server performs writes (e.g., updating wallpaper metadata), a persistent volume mounted at runtime will be needed and should be `chown`-ed accordingly in the compose file.

## Audit Note

**Reviewed**: Dockerfile, go.mod, cmd/server, wallpapers.go  
**Found & fixed**: container running as root + outdated alpine 3.21 base  
**Skipped / future run**: wallpapers.db committed to the repo (1.4 MB SQLite file) — consider adding it to `.dockerignore` and loading it from an external volume instead. The Gemini API key is passed as a plain environment variable in the compose file; consider moving to a secret manager.
