### PR TITLE
Fix CORS bypass: set AllowCredentials=false when AllowedOrigins is wildcard

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -158,12 +158,6 @@ func main() {
 	r.Use(secureMiddleware.Handler)
 
 	crs := cors.New(cors.Options{
-		// AllowCredentials must be false when AllowedOrigins is ["*"].
-		// Combining a wildcard origin with credentials causes go-chi/cors to
-		// reflect the incoming Origin header, allowing any site to make
-		// credentialed cross-origin requests (CORS bypass, CWE-942).
-		// The wallpapers service has no authentication mechanism and no
-		// endpoints that rely on cookies or session tokens.
 		AllowCredentials:   false,
 		OptionsPassthrough: false,
 		AllowedOrigins:     []string{"*"},

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -158,7 +158,13 @@ func main() {
 	r.Use(secureMiddleware.Handler)
 
 	crs := cors.New(cors.Options{
-		AllowCredentials:   true,
+		// AllowCredentials must be false when AllowedOrigins is ["*"].
+		// Combining a wildcard origin with credentials causes go-chi/cors to
+		// reflect the incoming Origin header, allowing any site to make
+		// credentialed cross-origin requests (CORS bypass, CWE-942).
+		// The wallpapers service has no authentication mechanism and no
+		// endpoints that rely on cookies or session tokens.
+		AllowCredentials:   false,
 		OptionsPassthrough: false,
 		AllowedOrigins:     []string{"*"},
 		AllowedMethods:     []string{"GET", "POST", "OPTIONS"},


### PR DESCRIPTION
## Problem

`cmd/server/main.go` configures CORS with `AllowCredentials: true` and `AllowedOrigins: []string{"*"}`:

```go
// BEFORE (vulnerable)
crs := cors.New(cors.Options{
    AllowCredentials:   true,   // ← dangerous with wildcard origin
    AllowedOrigins:     []string{"*"},
    ...
})
```

When credentials are enabled, `go-chi/cors` cannot use a wildcard origin — instead it reflects the incoming `Origin` header. The effective response becomes `Access-Control-Allow-Origin: <attacker.com>` with `Access-Control-Allow-Credentials: true`, allowing **any website** to make credentialed cross-origin requests to `walls.natwelch.com` (CORS bypass, CWE-942).

## Impact

The wallpapers service is read-only with no authentication, so the concrete risk is limited to information disclosure of image metadata. However, the misconfiguration is easily demonstrable and should be corrected as a matter of security hygiene. The same pattern has been fixed in sibling services (`inspiration`, `gotak`, `reportd` already had a correct comment explaining this).

## Fix

Set `AllowCredentials: false`. The service has no authentication, no cookies, and no endpoints that require credentialed access. This has no functional impact.

```go
// AFTER (safe)
crs := cors.New(cors.Options{
    AllowCredentials:   false,  // ← correct; wildcard + credentials must not mix
    AllowedOrigins:     []string{"*"},
    ...
})
```

## Testing steps

1. `go build ./cmd/server/...` — should compile cleanly.
2. `go test ./...` — existing tests should pass.
3. Make a cross-origin request to `walls.natwelch.com` from any origin and verify the response contains `Access-Control-Allow-Origin: *` and no `Access-Control-Allow-Credentials` header.

## Audit note

**Reviewed:** `cmd/server/main.go`, `go.mod`, `Dockerfile`, `wallpapers.go`.

**Other findings (not fixed here):**
- `wallpapers.db` (a SQLite file) is committed to the repository. This is a data hygiene concern — binary blobs in git make history bloated and diffs unreadable. Consider `.gitignore`-ing it and providing a seed script instead.
- `cmd/server/main.go` uses `html/template` correctly — no XSS risk in template rendering.
- Missing `ReadHeaderTimeout` on the `http.Server`; consider adding it in a future PR.
- Dependencies look current.

**No existing `audit/` PR on this repo before this one.**
