### PR TITLE
Add ReadHeaderTimeout to HTTP server (slow-loris defence)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -361,11 +361,12 @@ func main() {
 	})
 
 	srv := &http.Server{
-		Addr:         ":" + port,
-		Handler:      r,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		IdleTimeout:  10 * time.Second,
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	log.Fatal(srv.ListenAndServe())


### PR DESCRIPTION
## Problem

`cmd/server/main.go` creates an `http.Server` with three timeout fields but is **missing `ReadHeaderTimeout`**:

```go
// BEFORE
srv := &http.Server{
    Addr:         ":" + port,
    Handler:      r,
    ReadTimeout:  10 * time.Second,
    WriteTimeout: 10 * time.Second,
    IdleTimeout:  10 * time.Second,   // also unusually short
}
```

`ReadHeaderTimeout` is the primary defence against **slow-loris attacks**: a client that connects and then trickles HTTP headers one byte at a time never completes the request, holding the TCP connection open indefinitely. Without `ReadHeaderTimeout`, `ReadTimeout` does not protect against this pattern because `ReadTimeout` only begins counting once the first byte of the body arrives — header dribbling is not bounded. Under enough such connections the server exhausts its file descriptor limit.

The `IdleTimeout` of 10 seconds is also unusually short for a keep-alive server; browsers and proxies that keep connections open between page loads will see excessive reconnections.

## Fix

```go
// AFTER
srv := &http.Server{
    Addr:              ":" + port,
    Handler:           r,
    ReadHeaderTimeout: 5 * time.Second,   // new — slow-loris defence
    ReadTimeout:       10 * time.Second,
    WriteTimeout:      10 * time.Second,
    IdleTimeout:       60 * time.Second,  // was 10s
}
```

## Testing steps

1. `go build ./cmd/server` — must compile cleanly.
2. Run `./server &` — should start without errors.
3. `curl http://localhost:8080/healthz` — should return `hi.`.
4. To exercise the timeout: `nc localhost 8080`, then type `GET / HTTP/1.1` very slowly (one character per 2 seconds) — the connection should be dropped after 5 seconds total.

## Audit note

**Reviewed:** `cmd/server/main.go`, `go.mod`, `Dockerfile`, open PRs.

**Other findings (not fixed here):**
- Dependabot PRs #193/#194/#195/#196 are open for dependency bumps — recommend merging those.
- `wallpapers.db` (1.5 MB) is committed to the repository and baked into the Docker image. This is intentional (read-only seed data) but means any data update requires a new image. This is an accepted trade-off noted in the README; no action needed from this audit.
- The `imagick.v3` binding pulls in ImageMagick. CVE-2026-40311 (heap use-after-free in XMP handling, Medium) affects versions below 7.1.2-19. The Alpine 3.22 base image ships ImageMagick 7.1.1-x; the open Dependabot PR #196 bumps to Alpine 3.23, which includes the fixed 7.1.2-x series. Recommend merging PR #196 to resolve this CVE.
