### PR TITLE
fix: address golangci-lint findings

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"image"
+	// Register decoders for GIF, JPEG, and PNG so image.Decode/DecodeConfig can handle them.
 	_ "image/gif"
 	_ "image/jpeg"
 	_ "image/png"
@@ -16,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/EdlinOrg/prominentcolor"
+	// Register the WebP decoder so image.Decode/DecodeConfig can handle WebP files.
 	_ "golang.org/x/image/webp"
 	"google.golang.org/genai"
 )

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,5 @@
+// Command server runs the wallpapers HTTP service: it serves the web UI,
+// JSON API, and metrics endpoint backed by the wallpapers SQLite database.
 package main
 
 import (
@@ -96,7 +98,7 @@ func routeTag(next http.Handler) http.Handler {
 }
 
 // loadTemplate parses layout.tmpl and the named page file into a single template set.
-func loadTemplate(name string, funcs template.FuncMap) (*template.Template, error) {
+func loadTemplate(name string) (*template.Template, error) {
 	layoutContent, err := static.Assets.ReadFile("layout.tmpl")
 	if err != nil {
 		return nil, fmt.Errorf("read layout.tmpl: %w", err)
@@ -105,13 +107,10 @@ func loadTemplate(name string, funcs template.FuncMap) (*template.Template, erro
 	if err != nil {
 		return nil, fmt.Errorf("read %s.tmpl: %w", name, err)
 	}
-	base := template.FuncMap{
+	funcs := template.FuncMap{
 		"currentYear": func() int { return time.Now().Year() },
 	}
-	for k, v := range funcs {
-		base[k] = v
-	}
-	t := template.New("layout").Funcs(base)
+	t := template.New("layout").Funcs(funcs)
 	if t, err = t.Parse(string(layoutContent)); err != nil {
 		return nil, fmt.Errorf("parse layout.tmpl: %w", err)
 	}
@@ -143,19 +142,19 @@ func main() {
 		}
 	}()
 
-	if indexTemplate, err = loadTemplate("index", nil); err != nil {
+	if indexTemplate, err = loadTemplate("index"); err != nil {
 		log.Fatalw("failed to load index template", zap.Error(err))
 	}
-	if detailTemplate, err = loadTemplate("detail", nil); err != nil {
+	if detailTemplate, err = loadTemplate("detail"); err != nil {
 		log.Fatalw("failed to load detail template", zap.Error(err))
 	}
-	if resolutionsTemplate, err = loadTemplate("resolutions", nil); err != nil {
+	if resolutionsTemplate, err = loadTemplate("resolutions"); err != nil {
 		log.Fatalw("failed to load resolutions template", zap.Error(err))
 	}
-	if colorsTemplate, err = loadTemplate("colors", nil); err != nil {
+	if colorsTemplate, err = loadTemplate("colors"); err != nil {
 		log.Fatalw("failed to load colors template", zap.Error(err))
 	}
-	if tagsTemplate, err = loadTemplate("tags", nil); err != nil {
+	if tagsTemplate, err = loadTemplate("tags"); err != nil {
 		log.Fatalw("failed to load tags template", zap.Error(err))
 	}
 
@@ -416,5 +415,7 @@ func main() {
 		IdleTimeout:       60 * time.Second,
 	}
 
-	log.Fatal(srv.ListenAndServe())
+	if err := srv.ListenAndServe(); err != nil {
+		log.Errorw("http server exited", zap.Error(err))
+	}
 }

--- a/cmd/server/static/static.go
+++ b/cmd/server/static/static.go
@@ -1,3 +1,5 @@
+// Package static embeds the HTML templates, CSS, and other static assets
+// served by the wallpapers HTTP server.
 package static
 
 import "embed"

--- a/cmd/server/templates_test.go
+++ b/cmd/server/templates_test.go
@@ -13,19 +13,19 @@ import (
 func loadAll(t *testing.T) {
 	t.Helper()
 	var err error
-	if indexTemplate, err = loadTemplate("index", nil); err != nil {
+	if indexTemplate, err = loadTemplate("index"); err != nil {
 		t.Fatalf("load index: %v", err)
 	}
-	if detailTemplate, err = loadTemplate("detail", nil); err != nil {
+	if detailTemplate, err = loadTemplate("detail"); err != nil {
 		t.Fatalf("load detail: %v", err)
 	}
-	if resolutionsTemplate, err = loadTemplate("resolutions", nil); err != nil {
+	if resolutionsTemplate, err = loadTemplate("resolutions"); err != nil {
 		t.Fatalf("load resolutions: %v", err)
 	}
-	if colorsTemplate, err = loadTemplate("colors", nil); err != nil {
+	if colorsTemplate, err = loadTemplate("colors"); err != nil {
 		t.Fatalf("load colors: %v", err)
 	}
-	if tagsTemplate, err = loadTemplate("tags", nil); err != nil {
+	if tagsTemplate, err = loadTemplate("tags"); err != nil {
 		t.Fatalf("load tags: %v", err)
 	}
 }

--- a/cmd/uploader/main.go
+++ b/cmd/uploader/main.go
@@ -1,3 +1,6 @@
+// Command uploader walks the local Dropbox wallpapers folder, normalizes
+// filenames, upscales small images, uploads new/changed files to GCS, and
+// records image metadata in the wallpapers database.
 package main
 
 import (
@@ -18,6 +21,7 @@ import (
 	"gopkg.in/gographics/imagick.v3/imagick"
 )
 
+// DropboxPath is the location, relative to ~/Dropbox, where local wallpapers live.
 const DropboxPath = "/Photos/Wallpapers/DesktopWallpapers"
 
 var (
@@ -26,6 +30,12 @@ var (
 )
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatalf("uploader failed: %+v", err)
+	}
+}
+
+func run() error {
 	imagick.Initialize()
 	defer imagick.Terminate()
 
@@ -35,8 +45,7 @@ func main() {
 	var err error
 	database, err = db.Open(db.DefaultDBPath())
 	if err != nil {
-		log.Printf("error opening database: %+v", err)
-		os.Exit(1)
+		return fmt.Errorf("error opening database: %w", err)
 	}
 	defer func() {
 		if cerr := database.Close(); cerr != nil {
@@ -46,35 +55,30 @@ func main() {
 
 	// Run data migrations
 	if err := database.RunMigrations(); err != nil {
-		log.Printf("error running migrations: %+v", err)
-		os.Exit(1)
+		return fmt.Errorf("error running migrations: %w", err)
 	}
 
 	knownRemoteFiles, err := wallpapers.GetAll(ctx)
 	if err != nil {
-		log.Printf("error walking: %+v", err)
-		os.Exit(1)
+		return fmt.Errorf("error listing remote files: %w", err)
 	}
 	knownLocalFiles = map[string]bool{}
 
 	u, err := user.Lookup("nat")
 	if err != nil {
-		log.Printf("error getting nat: %+v", err)
-		os.Exit(1)
+		return fmt.Errorf("error getting nat: %w", err)
 	}
 	localFiles := filepath.Join(u.HomeDir, "Dropbox", DropboxPath)
 
 	if err := filepath.Walk(localFiles, walkFn); err != nil {
-		log.Printf("error walking: %+v", err)
-		os.Exit(1)
+		return fmt.Errorf("error walking: %w", err)
 	}
 
 	for _, file := range knownRemoteFiles {
 		filename := file.Name
 		if !knownLocalFiles[filename] {
 			if err := wallpapers.DeleteFile(ctx, filename); err != nil {
-				log.Printf("could not delete %q: %+v", filename, err)
-				os.Exit(1)
+				return fmt.Errorf("could not delete %q: %w", filename, err)
 			}
 			// Also remove from database
 			if err := database.Delete(filename); err != nil {
@@ -83,6 +87,8 @@ func main() {
 			log.Printf("deleted %q", filename)
 		}
 	}
+
+	return nil
 }
 
 func walkFn(path string, info fs.FileInfo, err error) error {
@@ -159,13 +165,14 @@ func walkFn(path string, info fs.FileInfo, err error) error {
 	needsAnalysis := false
 	reason := ""
 
-	if existing == nil || existing.ProcessedAt == nil {
+	switch {
+	case existing == nil || existing.ProcessedAt == nil:
 		needsAnalysis = true
 		reason = "not processed"
-	} else if len(existing.Words) == 0 {
+	case len(existing.Words) == 0:
 		needsAnalysis = true
 		reason = "words empty"
-	} else if shouldRandomlyReanalyze() {
+	case shouldRandomlyReanalyze():
 		needsAnalysis = true
 		reason = "random reanalysis (10%)"
 	}

--- a/wallpapers.go
+++ b/wallpapers.go
@@ -1,3 +1,5 @@
+// Package wallpapers provides helpers for managing wallpaper files stored in
+// Google Cloud Storage, including CRC checksums, URL generation, and metadata.
 package wallpapers
 
 import (
@@ -17,10 +19,12 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+// Bucket is the GCS bucket name where wallpaper files are stored.
 const (
 	Bucket = "iccowalls"
 )
 
+// NameRegex matches characters that are not allowed in normalized wallpaper file names.
 var (
 	NameRegex = regexp.MustCompile("[^a-z0-9]")
 )
@@ -45,12 +49,14 @@ func FormatName(in string) string {
 		babbler.Separator = ""
 		babbler.Count = 1
 
-		name = name + babbler.Babble()
+		name += babbler.Babble()
 	}
 
 	return name + ext
 }
 
+// GetGoogleCRC returns the CRC32C checksum that GCS has stored for the given object.
+// If the object does not exist, it returns 0 with a nil error.
 func GetGoogleCRC(ctx context.Context, filename string) (uint32, error) {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
@@ -71,10 +77,12 @@ func GetGoogleCRC(ctx context.Context, filename string) (uint32, error) {
 	return attr.CRC32C, nil
 }
 
+// GetFileCRC computes the CRC32C (Castagnoli) checksum of the given content.
 func GetFileCRC(content []byte) uint32 {
 	return crc32.Checksum(content, crc32.MakeTable(crc32.Castagnoli))
 }
 
+// DeleteFile removes the named object from the wallpaper GCS bucket.
 func DeleteFile(ctx context.Context, filename string) error {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
@@ -113,7 +121,7 @@ func FullRezURL(key string) string {
 	return fmt.Sprintf("https://icco-walls.imgix.net/%s?auto=compress&w=%d&h=%d&crop=entropy&fm=png", key, w, h)
 }
 
-// ThumbUrl returns the URL a small cropped version hosted by imgix.
+// ThumbURL returns the URL a small cropped version hosted by imgix.
 func ThumbURL(key string) string {
 	w := 800
 	h := 450


### PR DESCRIPTION
## Summary
The new golangci-lint workflow added stricter linters. This PR fixes the 16 findings so the lint check passes.

## Changes
- **revive (package-comments)**: added package doc comments to `wallpapers`, `cmd/server`, `cmd/server/static`, and `cmd/uploader`.
- **revive (exported)**: added doc comments to `Bucket`, `NameRegex`, `GetGoogleCRC`, `GetFileCRC`, `DeleteFile`, and `DropboxPath`.
- **revive (exported casing)**: fixed `ThumbUrl` doc-comment lead-in to `ThumbURL`.
- **revive (blank-imports)**: justified the `image/gif`/`image/jpeg`/`image/png`/`golang.org/x/image/webp` blank imports in `analysis/analysis.go`.
- **gocritic (exitAfterDefer)**: replaced `log.Fatal(srv.ListenAndServe())` in the server with an error log so deferred cleanup runs, and refactored `cmd/uploader/main.go` into a `run()` helper so `defer imagick.Terminate()` and the DB close defer run before exit.
- **gocritic (ifElseChain)**: replaced the if/else chain in `cmd/uploader/main.go` with a `switch` statement.
- **gocritic (assignOp)**: `name = name + ...` → `name += ...` in `FormatName`.
- **unparam**: dropped the always-nil `funcs template.FuncMap` parameter from `loadTemplate` and updated callers + tests.

## Verification
- `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert ./...` — 0 issues
- `go build ./...` — passes
- `go test ./...` — passes

Generated with [Claude Code](https://claude.com/claude-code)