### PR TITLE
fix: include search query in page title

### DIFF
--- a/cmd/server/static/index.tmpl
+++ b/cmd/server/static/index.tmpl
@@ -1,4 +1,4 @@
-{{define "title"}}Wallpapers{{end}}
+{{define "title"}}{{if .Query}}{{.Query}} - Wallpapers{{else}}Wallpapers{{end}}{{end}}
 
 {{define "container-class"}}p-4 max-w-5xl mx-auto{{end}}
 

--- a/cmd/server/templates_test.go
+++ b/cmd/server/templates_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"html/template"
+	"regexp"
 	"testing"
 	"time"
 
@@ -212,5 +213,41 @@ func assertContains(t *testing.T, body, want string) {
 	t.Helper()
 	if !bytes.Contains([]byte(body), []byte(want)) {
 		t.Errorf("expected output to contain %q", want)
+	}
+}
+
+func TestPageTitles(t *testing.T) {
+	loadAll(t)
+
+	titleRe := regexp.MustCompile(`<title>([^<]*)</title>`)
+	now := time.Now()
+	cases := []struct {
+		name string
+		tmpl *template.Template
+		data any
+		want string
+	}{
+		{"index", indexTemplate, PageData{}, "Wallpapers"},
+		{"index with query", indexTemplate, PageData{Query: "mountain"}, "mountain - Wallpapers"},
+		{"detail", detailTemplate, DetailPageData{Image: &db.Image{Filename: "sunset.jpg", DateAdded: now}}, "sunset.jpg - Wallpapers"},
+		{"resolutions", resolutionsTemplate, ResolutionsPageData{}, "Resolutions - Wallpapers"},
+		{"colors", colorsTemplate, ColorsPageData{}, "Colors - Wallpapers"},
+		{"tags", tagsTemplate, TagsPageData{}, "Tags - Wallpapers"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := tc.tmpl.Execute(&buf, tc.data); err != nil {
+				t.Fatalf("execute %s: %v", tc.name, err)
+			}
+			m := titleRe.FindStringSubmatch(buf.String())
+			if m == nil {
+				t.Fatalf("no <title> found in %s output", tc.name)
+			}
+			if m[1] != tc.want {
+				t.Errorf("title = %q, want %q", m[1], tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Side pages (tags, colors, resolutions, detail) already set their own `<title>`; the index never did, so `/?q=mountain` rendered bare "Wallpapers". Now renders `mountain - Wallpapers`, matching detail.tmpl's convention.

Adds a table-driven test that extracts `<title>` per page. The existing `assertContains(body, "Wallpapers")` passed trivially on every page and locked nothing in.